### PR TITLE
Mistake round, solves #11

### DIFF
--- a/src/vocgui/static/scripts.js
+++ b/src/vocgui/static/scripts.js
@@ -166,7 +166,7 @@ function getEditDistance(word_a, word_b){
     matrix[i] = [i];
   }
 
-  // increment each column in the first row
+  // increment each column in the first row.
   var j;
   for(j = 0; j <= word_a.length; j++){
     matrix[0][j] = j;
@@ -265,7 +265,7 @@ function reset_env() {
  * If user selects a set, start training session
  */
 $( "#select_training_set" ).change(function() {
-  new_training_session();
+  new_training_session(); 
 });
 
 /*

--- a/src/vocgui/static/scripts.js
+++ b/src/vocgui/static/scripts.js
@@ -97,7 +97,7 @@ function render_question_solved(current_document, content_textfield) {
 }
 
 /*load
- * Show results (correct/wrong) for training set.
+ * Show results (correct/wrong) for training set and provide buttons for new training sessions.
  */
 function render_end_result() {
   var html =  '<p>Gratulation, du hast die Lektion abgeschlossen. Dein Resultat:</p><p>' + documents_correct.length + ' Wörter waren korrekt.</p><p>' + documents_almost_correct.length + ' Wörter waren fast richtig.</p><p>' +
@@ -187,6 +187,7 @@ function getEditDistance(word_a, word_b){
 
   return matrix[word_b.length][word_a.length];
 };
+
 /*
  * Verify if user input matches word.
  */
@@ -235,7 +236,7 @@ function new_training_session() {
 }
 
 /*
- * Start new training session with wrong words only
+ * Start new training session with wrong words only.
  */
 
 function mistake_training_session() {

--- a/src/vocgui/static/scripts.js
+++ b/src/vocgui/static/scripts.js
@@ -235,7 +235,7 @@ function new_training_session() {
 }
 
 /*
- * Start new training session with wrong words
+ * Start new training session with wrong words only
  */
 
 function mistake_training_session() {


### PR DESCRIPTION
Adds the option of starting a new round with only the not correct words after you finished a session.

- Button "Fehler üben" added. Triggering the button causes the start of a new round with only the _not_ correct words of the last round.
- Function _mistake_training_session()_ added to set the global variables to the correct values in order to only use wrong words in the session.