### PR TITLE
Improvement almost right feedback, solves #5

### DIFF
--- a/src/vocgui/static/scripts.js
+++ b/src/vocgui/static/scripts.js
@@ -160,7 +160,6 @@ function check_current_document(second_try=false){
       hint = "Achte auf die Groß- und Kleinschreibung";
     var html = render_almost_right( current_document,$("#input_word").val(), hint);
     $("#div_ask_document").html(html);
-    prompt(hint);
     return;
   }
   

--- a/src/vocgui/static/scripts.js
+++ b/src/vocgui/static/scripts.js
@@ -98,7 +98,7 @@ function render_almost_right(current_document, content_textfield) {
               ((current_document["fields"]["audio"]) ? '<audio controls><source src="/media/'+ current_document["fields"]["audio"] +'" type="audio/ogg">Dein Browser unterstützt kein Audio.</audio>' +
               '<div class="col-xs-12" style="height:30px;"></div>' : '') +
               '<input id="input_word" class="form-control" type="text" value="'+ content_textfield + '" onkeypress="input_keypress(event);"' +
-              '<label for="male">Deine aktuelle Antwort war fast richtig, du hast einen Versuch sie in eine richtige Antwort umzuändern</label>'+
+              '<label for="male">Deine aktuelle Antwort war fast richtig, du hast einen Versuch sie in ein richtiges </label>'+
               '<div class="col-xs-12" style="height:30px;"></div>' +
               '<button type="button" class="btn btn-warning" onclick="check_current_document(true);">Erneut Überprüfen</button> '; 
   
@@ -242,23 +242,26 @@ function verify_document(old_document) {
     }
   })
   
+  //check if a mistake could result from Uppercase or Lowercase misusage
+  var case_sensitive_error = false;
+  if(getEditDistance(proofreading_word, new_document) != getEditDistance(proofreading_word.toLowerCase(), new_document.toLowerCase()))
+    case_sensitive_error = true;
+  
+  var verificationObject = {
+    status : "",
+    word_verified_against : proofreading_word,
+    case_sensitive_mistake : case_sensitive_error
+  } 
+
   if (mistake_rate == 0) {
-    var verificationObject = {
-      status : word_status.VALID,
-      word_verified_against : proofreading_word,
-    } 
+    verificationObject.status = word_status.VALID;
   } else if (mistake_rate <= 0.25) {
-    var verificationObject = {
-      status : word_status.ALMOST_VALID,
-      word_verified_against : proofreading_word,
-    }
+    verificationObject.status = word_status.ALMOST_VALID;
   } else {
-    var verificationObject = {
-      status : word_status.INVALID,
-      word_verified_against : proofreading_word,
-    }
+    verificationObject.status = word_status.INVALID;
   }
   return verificationObject;
+
 }
 
 /*

--- a/src/vocgui/static/scripts.js
+++ b/src/vocgui/static/scripts.js
@@ -92,13 +92,14 @@ function render_question(new_document) {
 /*
  *
  */
-function render_almost_right(current_document, content_textfield) {
+function render_almost_right(current_document, content_textfield, hint = "") {
   var html =  '<img class="img-fluid rounded" style="max-width: 90%;" src="/media/' + current_document["fields"]["image"] + '">' +
               '<div class="col-xs-12" style="height:30px;"></div>' +
               ((current_document["fields"]["audio"]) ? '<audio controls><source src="/media/'+ current_document["fields"]["audio"] +'" type="audio/ogg">Dein Browser unterstützt kein Audio.</audio>' +
               '<div class="col-xs-12" style="height:30px;"></div>' : '') +
               '<input id="input_word" class="form-control" type="text" value="'+ content_textfield + '" onkeypress="input_keypress(event);"' +
-              '<label for="male">Deine aktuelle Antwort war fast richtig, du hast einen Versuch sie in ein richtiges </label>'+
+              '<div class="col-xs-12" style="height:30px;"></div>' +
+              '<label>Deine aktuelle Antwort war fast richtig, du hast einen Versuch sie in ein richtiges Wort zu korrigieren</label>'+
               '<div class="col-xs-12" style="height:30px;"></div>' +
               '<button type="button" class="btn btn-warning" onclick="check_current_document(true);">Erneut Überprüfen</button> '; 
   
@@ -154,8 +155,12 @@ function check_current_document(second_try=false){
   var status = verificationObject.status;
   
   if(!second_try && status == word_status.ALMOST_VALID){
-    var html = render_almost_right( current_document,$("#input_word").val());
+    var hint = "";
+    if(verificationObject.case_sensitive_mistake)
+      hint = "Achte auf die Groß- und Kleinschreibung";
+    var html = render_almost_right( current_document,$("#input_word").val(), hint);
     $("#div_ask_document").html(html);
+    prompt(hint);
     return;
   }
   

--- a/src/vocgui/static/scripts.js
+++ b/src/vocgui/static/scripts.js
@@ -90,6 +90,23 @@ function render_question(new_document) {
 }
 
 /*
+ *
+ */
+function render_almost_right(current_document, content_textfield) {
+  var html =  '<img class="img-fluid rounded" style="max-width: 90%;" src="/media/' + current_document["fields"]["image"] + '">' +
+              '<div class="col-xs-12" style="height:30px;"></div>' +
+              ((current_document["fields"]["audio"]) ? '<audio controls><source src="/media/'+ current_document["fields"]["audio"] +'" type="audio/ogg">Dein Browser unterstützt kein Audio.</audio>' +
+              '<div class="col-xs-12" style="height:30px;"></div>' : '') +
+              '<input id="input_word" class="form-control" type="text" value="'+ content_textfield + '" onkeypress="input_keypress(event);"' +
+              '<label for="male">Deine aktuelle Antwort war fast richtig, du hast einen Versuch sie in eine richtige Antwort umzuändern</label>'+
+              '<div class="col-xs-12" style="height:30px;"></div>' +
+              '<button type="button" class="btn btn-warning" onclick="check_current_document(true);">Erneut Überprüfen</button> '; 
+  
+  return html;
+}
+
+
+/*
  * Render HTML code that shows the user the current image, the current audio and text field with given input which is read-only.
  */
 function render_question_solved(current_document, content_textfield) {
@@ -132,34 +149,40 @@ function load_new_document(){
 /*
 * Verifies the word the user wrote and calls functions to adapt UI fitting to verification.
 */
-function check_current_document(){
+function check_current_document(second_try=false){
   var verificationObject = verify_document(current_document);
   var status = verificationObject.status;
-  var content_textfield ;
+  
+  if(!second_try && status == word_status.ALMOST_VALID){
+    var html = render_almost_right( current_document,$("#input_word").val());
+    $("#div_ask_document").html(html);
+    return;
+  }
+  
   var styleClass ;
+  
   switch(status){
     case word_status.INVALID:
       documents_wrong.push(current_document);
-      content_textfield = $("#input_word").val();
       styleClass =  "invalid";
       break;
     case word_status.ALMOST_VALID:
       documents_almost_correct.push(current_document);
-      content_textfield = verificationObject.word_verified_against;
       styleClass = "almost_valid";
       break;
     case word_status.VALID:
       documents_correct.push(current_document);
-      content_textfield = verificationObject.word_verified_against;
       styleClass = "valid";
       break;
     default:
       console.error(word_status + " is an invalid parameter for the variable word_status");
   }
-  var html = render_question_solved(current_document, content_textfield);
+  var html = render_question_solved(current_document, $("#input_word").val());
   $("#div_ask_document").html(html);
   $("#input_word").addClass(styleClass); 
 }
+
+//änderung ui > click auf button soll weiter bedeuten 
 
 /*
  * Calculate Levenshtein distance between user input and right answer

--- a/src/vocgui/static/scripts.js
+++ b/src/vocgui/static/scripts.js
@@ -100,7 +100,7 @@ function render_almost_right(current_document, content_textfield, hint = "") {
               '<div class="col-xs-12" style="height:30px;"></div>' : '') +
               '<input id="input_word" class="form-control" type="text" value="'+ content_textfield + '" onkeypress="input_keypress(event);"' +
               '<div class="col-xs-12" style="height:30px;"></div>' +
-              '<label>Deine aktuelle Antwort war fast richtig, du hast einen Versuch sie in ein richtiges Wort zu korrigieren</label></br>'+
+              '<label>Deine aktuelle Antwort war fast richtig, du hast einen Versuch, sie in ein richtiges Wort zu korrigieren.</label></br>'+
               hint +
               '<div class="col-xs-12" style="height:30px;"></div>' +
               '<button type="button" class="btn btn-warning" onclick="check_current_document(true);">Erneut Überprüfen</button> '; 

--- a/src/vocgui/static/scripts.js
+++ b/src/vocgui/static/scripts.js
@@ -100,7 +100,8 @@ function render_almost_right(current_document, content_textfield, hint = "") {
               '<div class="col-xs-12" style="height:30px;"></div>' : '') +
               '<input id="input_word" class="form-control" type="text" value="'+ content_textfield + '" onkeypress="input_keypress(event);"' +
               '<div class="col-xs-12" style="height:30px;"></div>' +
-              '<label>Deine aktuelle Antwort war fast richtig, du hast einen Versuch sie in ein richtiges Wort zu korrigieren</label>'+
+              '<label>Deine aktuelle Antwort war fast richtig, du hast einen Versuch sie in ein richtiges Wort zu korrigieren</label></br>'+
+              hint +
               '<div class="col-xs-12" style="height:30px;"></div>' +
               '<button type="button" class="btn btn-warning" onclick="check_current_document(true);">Erneut Überprüfen</button> '; 
   
@@ -156,9 +157,9 @@ function check_current_document(second_try=false){
   var status = verificationObject.status;
   
   if(!second_try && status == word_status.ALMOST_VALID){
-    var hint = "";
+    var hint = ""
     if(verificationObject.case_sensitive_mistake)
-      hint = "Achte auf die Groß- und Kleinschreibung";
+      hint = "Hinweis: Achte auf die Groß- und Kleinschreibung";
     var html = render_almost_right( current_document,$("#input_word").val(), hint);
     $("#div_ask_document").html(html);
     return;

--- a/src/vocgui/static/scripts.js
+++ b/src/vocgui/static/scripts.js
@@ -90,7 +90,8 @@ function render_question(new_document) {
 }
 
 /*
- *
+ * Render HTML code that shows the user  the current image, the current audio, a text field with the last input, an advise that you got more chance to 
+ * corrcet your word and a possible hint. 
  */
 function render_almost_right(current_document, content_textfield, hint = "") {
   var html =  '<img class="img-fluid rounded" style="max-width: 90%;" src="/media/' + current_document["fields"]["image"] + '">' +


### PR DESCRIPTION
Adds a second try after you got something almost right. Moreover it provides the option to supply a hint together with that second try. It is also now checked if you made mistakes due to case sensitivity.

- By writing a new method: `render_almost_right(current_document, content_textfield, hint = "")`

- By adding an if clause to the `check_current_document()` function

- By adapting `verify_document()` and giving the `verificationObject` another attribute
